### PR TITLE
Add fake-hwclock

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ After the Pi is booted again, connect via SSH (if you don't have attached a keyb
 ### 3.3. NTP
 
 ```bash
-pacman -S ntp
+pacman -S ntp fake-hwclock
 systemctl enable ntpd.service
 systemctl start ntpd.service
 ```


### PR DESCRIPTION
Recently I have experienced that rebooting would cause the Pi to forget what the time was. Even though NTPD was enabled, it would require manually updating the system time via `ntpq -p` and prior to doing this the system date and time would be months out of sync.

Fake HWClock fixes this and it is also used in Raspbian.