### PR TITLE
Reorder and simplify update (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ There are 2 major versions of Raspberry Pi now. You may find the downloads on
 [www.archlinuxarm.org](http://www.archlinuxarm.org) for the latest version of Arch Linux for Raspberry Pi both 1 and 2.
 
 
+**For Raspberry Pi 3**
+```bash
+wget http://archlinuxarm.org/os/ArchLinuxARM-rpi-3-latest.tar.gz
+sudo tar -xpf ArchLinuxARM-rpi-3-latest.tar.gz -C root
+sync
+```
+
+
 **For Raspberry Pi 2**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -99,25 +99,19 @@ su
 The password is `root`.
 
 
-### 2.1. German keyboard layout and timezone
+### 2.1. German keyboard layout
 
 Of course just if you want to have a german keyboard layout. You may skip this step or use another layout.
 
 ```bash
 loadkeys de
-echo LANG=de_DE.UTF-8 > /etc/locale.conf
+echo LANG=en_US.UTF-8 > /etc/locale.conf
 echo KEYMAP=de-latin1-nodeadkeys > /etc/vconsole.conf
-rm /etc/localtime
-ln -s /usr/share/zoneinfo/Europe/Berlin /etc/localtime
-sed -i "s/en_US.UTF-8/#en_US.UTF-8/" /etc/locale.conf
+sed -i "s/#en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen
+locale-gen
 ```
 
-```bash
-export LANGUAGE=en_US.UTF-8
-export LANG=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
-locale-gen en_US.UTF-8
-```
+Logout and back in for the settings to take effect.
 
 
 ### 2.2. Setup swapfile
@@ -142,7 +136,7 @@ echo 'vm.swappiness=1' > /etc/sysctl.d/99-sysctl.conf
 ```bash
 timedatectl set-local-rtc 0
 
-nano /etc/timezone
+ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 ```
 
 * Set to "Europe/Berlin"

--- a/README.md
+++ b/README.md
@@ -151,12 +151,9 @@ sed -i 's/#Color/Color/' /etc/pacman.conf # Add color to pacman
 ### 3.2. System update
 
 ```bash
-pacman -Sy pacman
 pacman-key --init
-pacman -S archlinux-keyring
 pacman-key --populate archlinuxarm
-pacman -Syu --ignore filesystem
-pacman -S filesystem --force
+pacman -Syu
 reboot
 ```
 


### PR DESCRIPTION
**Edit:**
Ooops, I did it wrong. I meant to offer my changes in different PRs but I messed it up. Before I cause any more confusion by closing and redoing it, I'll leave it here as it is (for now) and wait for your response first. Only the first commit ([f6149cf](/phortx/Raspberry-Pi-Setup-Guide/pull/16/commits/f6149cf117978f6b52941b30ced3f7e75f004203)) was meant to be in this PR.

**Original text**
I did a clean install on my Raspberry Pi an hour ago. I followed the instructions [here](https://archlinuxarm.org/platforms/armv6/raspberry-pi) and I came across your guide. If you initialize and populate the keyring first, you can do a simple `pacman -Syu` afterwards and everything is fine.

This PR reorders the commands accordingly and also removes the ones that aren't needed anymore because a successfull `pacman -Syu` takes care of everything in one go. (I'm guessing there have been issues with that in the past and that's why you've had it split into multiple commands.)